### PR TITLE
chore: Add caret to Next.js version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.539.0",
-    "next": "15.5.2",
+    "next": "^15.5.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "tailwind-merge": "^3.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
         specifier: ^0.539.0
         version: 0.539.0(react@19.1.1)
       next:
-        specifier: 15.5.2
+        specifier: ^15.5.2
         version: 15.5.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react:
         specifier: ^19.1.1


### PR DESCRIPTION
### TL;DR

Updated Next.js dependency to use caret version range instead of fixed version.

### What changed?

Changed the Next.js dependency in package.json from a fixed version `15.5.2` to a caret version range `^15.5.2`, which allows for compatible minor and patch updates. The corresponding change was also reflected in the pnpm-lock.yaml file.

### How to test?

1. Run `pnpm install` to verify the dependency resolves correctly
2. Start the development server with `pnpm dev` to ensure the application runs properly
3. Verify that the application functionality works as expected with the updated dependency configuration

### Why make this change?

Using the caret version range (`^`) allows for automatic installation of compatible minor and patch updates to Next.js without requiring manual version bumps. This follows best practices for dependency management, ensuring security patches and bug fixes are automatically included while maintaining compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Next.js dependency to a caret range (^15.5.2) to allow automatic minor and patch updates within 15.x.
  * Ensures quicker access to performance improvements, bug fixes, and security patches without manual version bumps.
  * No user-facing functionality changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->